### PR TITLE
Group posts

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -95,11 +95,11 @@ exports.createPages = ({ graphql, actions }) => {
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 
-    if (node.frontmatter) {
+  if (node.frontmatter) {
       createNodeField({
         node,
-        name: 'year_month',
-        value: moment(node.frontmatter.date).format('YYYY_MMMM')
+        name: 'month_stamp',
+        value: moment(moment(node.frontmatter.date).format('YYYY-MM')).format()
       })
     }
   if (node.internal.type === 'File') {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,3 +1,4 @@
+const moment = require('moment')
 const _ = require('lodash')
 const Promise = require('bluebird')
 const path = require('path')
@@ -51,7 +52,7 @@ exports.createPages = ({ graphql, actions }) => {
           createPage({
             path: edge.node.fields.slug,
             component: slash(postTemplate),
-            context: { slug: edge.node.fields.slug },
+            context: { slug: edge.node.fields.slug},
           })
 
           let tags = []
@@ -94,6 +95,13 @@ exports.createPages = ({ graphql, actions }) => {
 exports.onCreateNode = ({ node, actions, getNode }) => {
   const { createNodeField } = actions
 
+    if (node.frontmatter) {
+      createNodeField({
+        node,
+        name: 'month',
+        value: moment(node.frontmatter.date).format('MMMM')
+      })
+    }
   if (node.internal.type === 'File') {
     const parsedFilePath = path.parse(node.absolutePath)
     const slug = `/${parsedFilePath.dir.split('---')[1]}/`
@@ -112,6 +120,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
       name: 'slug',
       value: slug,
     })
+
 
     if (node.frontmatter.tags) {
       const tagSlugs = node.frontmatter.tags.map(

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -98,13 +98,8 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     if (node.frontmatter) {
       createNodeField({
         node,
-        name: 'month',
-        value: moment(node.frontmatter.date).format('MMMM')
-      })
-      createNodeField({
-        node,
-        name: 'year',
-        value: moment(node.frontmatter.date).format('YYYY')
+        name: 'year_month',
+        value: moment(node.frontmatter.date).format('YYYY_MMMM')
       })
     }
   if (node.internal.type === 'File') {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -101,6 +101,11 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
         name: 'month',
         value: moment(node.frontmatter.date).format('MMMM')
       })
+      createNodeField({
+        node,
+        name: 'year',
+        value: moment(node.frontmatter.date).format('YYYY')
+      })
     }
   if (node.internal.type === 'File') {
     const parsedFilePath = path.parse(node.absolutePath)

--- a/src/assets/scss/base/_generic.scss
+++ b/src/assets/scss/base/_generic.scss
@@ -173,3 +173,4 @@ figcaption {
     }    
 }
 
+

--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -30,7 +30,7 @@ class Footer extends React.Component {
 
     return (
       <div className="footer">
-        <hr style={{marginBottom: 20}}/>
+        <hr style={{width: 250, marginTop: 10, marginBottom: 20}}/>
         <div className="footer__inner">
           <div className="footer__author">{authorBlock}</div>
           <div>

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -29,11 +29,11 @@ class Post extends React.Component {
             </Link>
           </span>
         </div>
-        <h2 className="post__title">
+        <h3 className="post__title">
           <Link className="post__title-link" to={slug}>
             {title}
           </Link>
-        </h2>
+        </h3>
         <p className="post__description">{description}</p>
       </div>
     )

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'gatsby'
 import moment from 'moment'
 import './style.scss'
+import feather from 'feather-icons'
 
 class Post extends React.Component {
   render() {
@@ -16,6 +17,14 @@ class Post extends React.Component {
     return (
       <li value={moment(date).format('DD')}>
         <div style={{display: 'flex', flexDirection: 'row'}}className="post">
+            <div className="post__meta">
+            <span className="post__meta-category" key={categorySlug}>
+              <Link to={categorySlug} className="post__meta-category-link">
+                {category}
+              </Link>
+            </span>
+          </div>
+            <span className="post__meta-divider" />
           <h3 className="post__title">
           <span className="post__meta">
             <time
@@ -27,14 +36,6 @@ class Post extends React.Component {
               {title}
             </Link>
           </h3>
-            <span className="post__meta-divider" />
-            <div className="post__meta">
-            <span className="post__meta-category" key={categorySlug}>
-              <Link to={categorySlug} className="post__meta-category-link">
-                {category}
-              </Link>
-            </span>
-          </div>
 
 
       </div>

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -15,25 +15,29 @@ class Post extends React.Component {
 
     return (
       <div className="post">
-        <div className="post__meta">
-          <time
-            className="post__meta-time"
-            dateTime={moment(date).format('MMMM D, YYYY')}
-          >
-            {moment(date).format('MMMM YYYY')}
-          </time>
-          <span className="post__meta-divider" />
-          <span className="post__meta-category" key={categorySlug}>
-            <Link to={categorySlug} className="post__meta-category-link">
-              {category}
-            </Link>
+
+          <h3 className="post__title">
+          <span className="post__meta">
+            <time
+              className="post__meta-time"
+              dateTime={moment(date).format('MMMM D, YYYY')}
+            >
+              {moment(date).format('DD')}
+            </time>
+            <span className="post__meta-divider" />
           </span>
-        </div>
-        <h3 className="post__title">
-          <Link className="post__title-link" to={slug}>
-            {title}
-          </Link>
-        </h3>
+            <Link className="post__title-link" to={slug}>
+              {title}
+            </Link>
+          </h3>
+            <div className="post__meta">
+            <span className="post__meta-category" key={categorySlug}>
+              <Link to={categorySlug} className="post__meta-category-link">
+                {category}
+              </Link>
+            </span>
+          </div>
+
         <p className="post__description">{description}</p>
       </div>
     )

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -15,8 +15,7 @@ class Post extends React.Component {
 
     return (
       <li value={moment(date).format('DD')}>
-      <div className="post">
-
+        <div style={{display: 'flex', flexDirection: 'row'}}className="post">
           <h3 className="post__title">
           <span className="post__meta">
             <time
@@ -28,7 +27,7 @@ class Post extends React.Component {
               {title}
             </Link>
           </h3>
-
+            <span className="post__meta-divider" />
             <div className="post__meta">
             <span className="post__meta-category" key={categorySlug}>
               <Link to={categorySlug} className="post__meta-category-link">
@@ -37,7 +36,7 @@ class Post extends React.Component {
             </span>
           </div>
 
-        <p className="post__description">{description}</p>
+
       </div>
       </li>
     )

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -16,16 +16,18 @@ class Post extends React.Component {
 
     return (
       <div className="post">
-        <div className="post__title-row">
+        <div style={{display: 'flex', flexDirection: 'row'}}className="post__title-row">
+            <span className="post__meta-divider" />
+            <div style={{position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: '#5d93ff', color: 'white', height: 48, width: 48, borderRadius: 50, paddingTop: 2}}>
+            <i dangerouslySetInnerHTML={{ __html: feather.icons.calendar.toSvg({height: 36, width: 36, color: 'white'}) }} />
+              <span style={{position: 'absolute', bottom: 7, left: 15}}>{moment(date).format('DD')}</span>
+            </div>
             <time
               className="post__meta-time"
               dateTime={moment(date).format('MMMM D, YYYY')}
               style={{position: 'relative'}}
             >
-              <i dangerouslySetInnerHTML={{ __html: feather.icons.calendar.toSvg({height: 36, width: 36, color: 'white', zIndex: 10}) }} />
-              <span style={{position: 'absolute', bottom: 5, left: 12, backgroundColor: '#5d93ff', color: 'white', lineHeight: '40px', width: 40, borderRadius: 50, textAlign: 'center'}}>{moment(date).format('DD')}</span>
             </time>
-            <span classNme="post__meta-divider" />
           <h3 className="post__title">
             <Link className="post__title-link" to={slug}>
               {title}

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -16,16 +16,16 @@ class Post extends React.Component {
 
     return (
       <li value={moment(date).format('DD')}>
-        <div style={{display: 'flex', flexDirection: 'row'}}className="post">
-            <div className="post__meta">
+        <div className="post">
+          <h3 className="post__title">
+
             <span className="post__meta-category" key={categorySlug}>
               <Link to={categorySlug} className="post__meta-category-link">
                 {category}
               </Link>
             </span>
-          </div>
+
             <span className="post__meta-divider" />
-          <h3 className="post__title">
           <span className="post__meta">
             <time
               className="post__meta-time"

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -15,6 +15,7 @@ class Post extends React.Component {
     const { slug, categorySlug } = this.props.data.node.fields
 
     return (
+      <li value={moment(date).format('DD')}>
       <div className="post">
         <div style={{display: 'flex', flexDirection: 'row'}}className="post__title-row">
             <span className="post__meta-divider" />
@@ -25,10 +26,8 @@ class Post extends React.Component {
             <time
               className="post__meta-time"
               dateTime={moment(date).format('MMMM D, YYYY')}
-              style={{position: 'relative'}}
-            >
-            </time>
-          <h3 className="post__title">
+            />
+          </span>
             <Link className="post__title-link" to={slug}>
               {title}
             </Link>
@@ -43,6 +42,7 @@ class Post extends React.Component {
         </div>
         <p className="post__description">{description}</p>
       </div>
+      </li>
     )
   }
 }

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Link } from 'gatsby'
 import moment from 'moment'
 import './style.scss'
-import feather from 'feather-icons'
 
 class Post extends React.Component {
   render() {
@@ -17,12 +16,9 @@ class Post extends React.Component {
     return (
       <li value={moment(date).format('DD')}>
       <div className="post">
-        <div style={{display: 'flex', flexDirection: 'row'}}className="post__title-row">
-            <span className="post__meta-divider" />
-            <div style={{position: 'relative', display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: '#5d93ff', color: 'white', height: 48, width: 48, borderRadius: 50, paddingTop: 2}}>
-            <i dangerouslySetInnerHTML={{ __html: feather.icons.calendar.toSvg({height: 36, width: 36, color: 'white'}) }} />
-              <span style={{position: 'absolute', bottom: 7, left: 15}}>{moment(date).format('DD')}</span>
-            </div>
+
+          <h3 className="post__title">
+          <span className="post__meta">
             <time
               className="post__meta-time"
               dateTime={moment(date).format('MMMM D, YYYY')}
@@ -32,14 +28,15 @@ class Post extends React.Component {
               {title}
             </Link>
           </h3>
-          {/*            <div className="post__meta">
+
+            <div className="post__meta">
             <span className="post__meta-category" key={categorySlug}>
               <Link to={categorySlug} className="post__meta-category-link">
                 {category}
               </Link>
             </span>
-          </div>*/}
-        </div>
+          </div>
+
         <p className="post__description">{description}</p>
       </div>
       </li>

--- a/src/components/Post/index.jsx
+++ b/src/components/Post/index.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Link } from 'gatsby'
 import moment from 'moment'
 import './style.scss'
+import feather from 'feather-icons'
 
 class Post extends React.Component {
   render() {
@@ -15,29 +16,29 @@ class Post extends React.Component {
 
     return (
       <div className="post">
-
-          <h3 className="post__title">
-          <span className="post__meta">
+        <div className="post__title-row">
             <time
               className="post__meta-time"
               dateTime={moment(date).format('MMMM D, YYYY')}
+              style={{position: 'relative'}}
             >
-              {moment(date).format('DD')}
+              <i dangerouslySetInnerHTML={{ __html: feather.icons.calendar.toSvg({height: 36, width: 36, color: 'white', zIndex: 10}) }} />
+              <span style={{position: 'absolute', bottom: 5, left: 12, backgroundColor: '#5d93ff', color: 'white', lineHeight: '40px', width: 40, borderRadius: 50, textAlign: 'center'}}>{moment(date).format('DD')}</span>
             </time>
-            <span className="post__meta-divider" />
-          </span>
+            <span classNme="post__meta-divider" />
+          <h3 className="post__title">
             <Link className="post__title-link" to={slug}>
               {title}
             </Link>
           </h3>
-            <div className="post__meta">
+          {/*            <div className="post__meta">
             <span className="post__meta-category" key={categorySlug}>
               <Link to={categorySlug} className="post__meta-category-link">
                 {category}
               </Link>
             </span>
-          </div>
-
+          </div>*/}
+        </div>
         <p className="post__description">{description}</p>
       </div>
     )

--- a/src/components/Post/style.scss
+++ b/src/components/Post/style.scss
@@ -10,7 +10,7 @@
         font-size: $typographic-base-font-size * 1.25;
         @include line-height(1.0);
         @include margin-top(0);
-        @include margin-bottom(.5);
+        @include margin-bottom(.1);
         &-link {
             color: $color-base;
             &:hover,

--- a/src/components/Post/style.scss
+++ b/src/components/Post/style.scss
@@ -7,16 +7,18 @@
         @include margin-bottom(.5);
     }
     &__title {
-        font-size: $typographic-base-font-size * 1.25;
+        font-size: $typographic-base-font-size * 1.1;
+        font-weight: 400;
         @include line-height(1.0);
         @include margin-top(0);
         @include margin-bottom(.1);
         &-link {
             color: $color-base;
+            border-bottom: 1px solid $color-secondary;
             &:hover,
             &:focus {
                 color: $color-base;
-                border-bottom: 1px solid $color-base;
+                border-bottom: 1px solid $color-primary;
             }
         }
     }

--- a/src/components/Post/style.scss
+++ b/src/components/Post/style.scss
@@ -33,7 +33,6 @@
             font-weight: 500;
             text-transform: uppercase;
 //            padding: 3px;
-//            border: 2px solid $color-primary;
         }
         &-divider {
             margin: 0 5px;

--- a/src/components/Post/style.scss
+++ b/src/components/Post/style.scss
@@ -7,8 +7,8 @@
         @include margin-bottom(.5);
     }
     &__title {
-        font-size: $typographic-base-font-size * 1.6875;
-        @include line-height(1.5);
+        font-size: $typographic-base-font-size * 1.4875;
+        @include line-height(1.3);
         @include margin-top(0);
         @include margin-bottom(.5);
         &-link {

--- a/src/components/Post/style.scss
+++ b/src/components/Post/style.scss
@@ -7,8 +7,8 @@
         @include margin-bottom(.5);
     }
     &__title {
-        font-size: $typographic-base-font-size * 1.4875;
-        @include line-height(1.3);
+        font-size: $typographic-base-font-size * 1.25;
+        @include line-height(1.0);
         @include margin-top(0);
         @include margin-bottom(.5);
         &-link {
@@ -31,6 +31,8 @@
             color: $color-base;
             font-weight: 500;
             text-transform: uppercase;
+            padding: 3px;
+            border: 2px solid $color-primary;
         }
         &-divider {
             margin: 0 5px;

--- a/src/components/Post/style.scss
+++ b/src/components/Post/style.scss
@@ -26,13 +26,14 @@
         @include margin-bottom(.75);
     }
     &__meta {
+        @include line-height(2.0);
         &-time {
             font-size: $typographic-small-font-size;
             color: $color-base;
             font-weight: 500;
             text-transform: uppercase;
-            padding: 3px;
-            border: 2px solid $color-primary;
+//            padding: 3px;
+//            border: 2px solid $color-primary;
         }
         &-divider {
             margin: 0 5px;

--- a/src/components/Post/style.scss
+++ b/src/components/Post/style.scss
@@ -26,7 +26,6 @@
         @include margin-bottom(.75);
     }
     &__meta {
-        @include line-height(2.0);
         &-time {
             font-size: $typographic-small-font-size;
             color: $color-base;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -9,10 +9,15 @@ class IndexRoute extends React.Component {
   render() {
     const items = []
     const { title, subtitle } = this.props.data.site.siteMetadata
-    const posts = this.props.data.allMarkdownRemark.edges
-    posts.forEach(post => {
-      items.push(<Post data={post} key={post.node.fields.slug} />)
-    })
+    const groups = this.props.data.allMarkdownRemark.group
+    const sections = groups.map(({fieldValue, edges: posts}) => (
+      <div>
+        <h3>{fieldValue}</h3>
+        {posts.map(post => (
+          <Post data={post} key={post.node.fields.slug} />
+        ))}
+      </div>
+    )).reverse()
 
     return (
       <Layout>
@@ -22,7 +27,7 @@ class IndexRoute extends React.Component {
             <meta name="description" content={subtitle} />
           </Helmet>
           <div className="content">
-            <div className="content__inner">{items}</div>
+            <div className="content__inner">{sections}</div>
           </div>
         </div>
       </Layout>
@@ -56,6 +61,8 @@ export const pageQuery = graphql`
       filter: { frontmatter: { layout: { eq: "post" }, draft: { ne: true } } }
       sort: { order: DESC, fields: [frontmatter___date] }
     ) {
+      group(field: fields___year_month) {
+        fieldValue
       edges {
         node {
           fields {
@@ -69,6 +76,7 @@ export const pageQuery = graphql`
             description
           }
         }
+      }
       }
     }
   }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -14,9 +14,11 @@ class IndexRoute extends React.Component {
     const sections = groups.map(({fieldValue, edges: posts}) => (
       <div>
         <h2>{moment(fieldValue).format('MMMM YYYY')}</h2>
-        {posts.map(post => (
-          <Post data={post} key={post.node.fields.slug} />
+        <ol>
+          {posts.map(post => (
+            <Post data={post} key={post.node.fields.slug} />
         ))}
+        </ol>
       </div>
     )).reverse()
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -4,6 +4,7 @@ import { graphql } from 'gatsby'
 import Layout from '../components/Layout'
 import Post from '../components/Post'
 import Sidebar from '../components/Sidebar'
+import moment from 'moment'
 // import Header from '../components/Header'
 class IndexRoute extends React.Component {
   render() {
@@ -12,7 +13,7 @@ class IndexRoute extends React.Component {
     const groups = this.props.data.allMarkdownRemark.group
     const sections = groups.map(({fieldValue, edges: posts}) => (
       <div>
-        <h3>{fieldValue}</h3>
+        <h2>{moment(fieldValue).format('MMMM YYYY')}</h2>
         {posts.map(post => (
           <Post data={post} key={post.node.fields.slug} />
         ))}
@@ -61,7 +62,7 @@ export const pageQuery = graphql`
       filter: { frontmatter: { layout: { eq: "post" }, draft: { ne: true } } }
       sort: { order: DESC, fields: [frontmatter___date] }
     ) {
-      group(field: fields___year_month) {
+      group(field: fields___month_stamp) {
         fieldValue
       edges {
         node {


### PR DESCRIPTION
* Lots of commits here that essentially add up to a relatively minor rearrangement of individual post items such that
    * description is gone
    * Post links look like links and aren't as heavy
    * posts are now list items in an ordered list where their value is the date of the month on which they were posted
    * categories now prepend titles
* Added a node field called `month_stamp` which is a timestamp of a specific month which allows us to group by something easily orderable but non-readable but which is then easy to parse into something readable via `moment` later. In other words, dates are trashboat but we have a funny solution.