### PR TITLE
hard code all month stamps to refer to the second to prevent tz backs…

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -99,7 +99,7 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
       createNodeField({
         node,
         name: 'month_stamp',
-        value: moment(moment(node.frontmatter.date).format('YYYY-MM')).format()
+        value: moment(moment(node.frontmatter.date).format('YYYY-MM-02')).format()
       })
     }
   if (node.internal.type === 'File') {


### PR DESCRIPTION
…lide

This is a funny one. By shoving raw timestamps parsed from 'YYYY-MM' strings, the tz difference on netflify's servers was backsliding the timestamps (which corresponds to midnight at the first of the month utc) to the previous month (since we're utc -8).